### PR TITLE
Issue 99 100

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,8 @@
 [run]
 source = branchpro
-omit = 
+omit =
     branchpro/tests/*
+    branchpro/apps/_dash_app.py
     branchpro/apps/_simulation.py
     branchpro/apps/simulation_dash_app.py
     branchpro/apps/_inference.py

--- a/Procfile_simulation/Procfile
+++ b/Procfile_simulation/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --workers=1 --pythonpath branchpro/apps simulation_dash_app:server
+web: gunicorn --workers=2 --pythonpath branchpro/apps simulation_dash_app:server

--- a/Procfile_simulation/Procfile
+++ b/Procfile_simulation/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --workers=2 --pythonpath branchpro/apps simulation_dash_app:server
+web: gunicorn --pythonpath branchpro/apps simulation_dash_app:server

--- a/branchpro/__init__.py
+++ b/branchpro/__init__.py
@@ -18,6 +18,6 @@ from .version_info import VERSION_INT, VERSION  # noqa
 # Import main classes
 from .models import ForwardModel, BranchProModel, LocImpBranchProModel    # noqa
 from .simulation import SimulationController  # noqa
-from .apps import IncidenceNumberPlot, _SliderComponent, IncidenceNumberSimulationApp, ReproductionNumberPlot, BranchProInferenceApp # noqa
+from .apps import IncidenceNumberPlot, _SliderComponent, BranchProDashApp, IncidenceNumberSimulationApp, ReproductionNumberPlot, BranchProInferenceApp # noqa
 from ._dataset_library_api import DatasetLibrary # noqa
 from .posterior import BranchProPosterior, LocImpBranchProPosterior # noqa

--- a/branchpro/apps/__init__.py
+++ b/branchpro/apps/__init__.py
@@ -13,3 +13,4 @@ from ._incidence_number_plot import IncidenceNumberPlot  # noqa
 from ._simulation import IncidenceNumberSimulationApp # noqa
 from ._reproduction_number_plot import ReproductionNumberPlot # noqa
 from ._inference import BranchProInferenceApp # noqa
+from ._dash_app import BranchProDashApp # noqa

--- a/branchpro/apps/__init__.py
+++ b/branchpro/apps/__init__.py
@@ -8,9 +8,9 @@
 #
 
 # Import main classes
+from ._dash_app import BranchProDashApp # noqa
 from ._sliders import _SliderComponent # noqa
 from ._incidence_number_plot import IncidenceNumberPlot  # noqa
 from ._simulation import IncidenceNumberSimulationApp # noqa
 from ._reproduction_number_plot import ReproductionNumberPlot # noqa
 from ._inference import BranchProInferenceApp # noqa
-from ._dash_app import BranchProDashApp # noqa

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -81,11 +81,12 @@ class BranchProDashApp:
             by the particular app, and each value should be a string containing
             the JSON data accessed from that storage.
         """
-        self.session_data = {}
+        self.new_session_data = {}
         for k, v in kwargs.items():
             if v is not None:
                 v = pd.read_json(v)
-            self.session_data[k] = v
+            self.new_session_data[k] = v
+        self.session_data = self.new_session_data
 
     def parse_contents(self, contents, filename):
         """Load a text (csv) file into a pandas dataframe.

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -8,6 +8,7 @@
 #
 
 import pandas as pd
+import dash_bootstrap_components as dbc
 
 
 class BranchProDashApp:

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -109,8 +109,8 @@ class BranchProDashApp:
         """Load a text (csv) file into a pandas dataframe.
 
         This method is for loading incidence number data. It expects files to
-        have two columns, the first with title `Time` and the second with title
-        `Incidence Number`.
+        have at least two columns, the first with title ``Time`` and the second
+        with title ``Incidence Number``.
 
         Parameters
         ----------
@@ -121,7 +121,7 @@ class BranchProDashApp:
 
         Returns
         -------
-        html Div
+        html.Div
             A div which contains a message for the user.
         pandas.DataFrame
             A dataframe with the loaded file. If the file load was not

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -7,6 +7,8 @@
 # notice and full license details.
 #
 
+import pandas as pd
+
 
 class BranchProDashApp:
     """Base class for dash apps for branching processes.

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -90,6 +90,10 @@ class BranchProDashApp:
     def parse_contents(self, contents, filename):
         """Load a text (csv) file into a pandas dataframe.
 
+        This method is for loading incidence number data. It expects files to
+        have two columns, the first with title `Time` and the second with title
+        `Incidence Number`.
+
         Parameters
         ----------
         contents : str

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -151,14 +151,43 @@ class BranchProDashApp:
         else:
             return html.Div(['Loaded data from: {}'.format(filename)]), df
 
-    def _load_text(self, text):
-        """Load text into an HTML div saved at self.text.
-        """
-        self.text = html.Div([text])
+    def add_text(self, text):
+        """Add a block of text at the top of the app.
 
-    def _load_collapsed_text(self, text, title):
-        """Load text into a hidden HTML div with button at self.collapsed_text.
+        This can be used to add introductory text that everyone looking at the
+        app will see right away.
+
+        Parameters
+        ----------
+        text : str
+            The text to add to the html div
         """
+        if not hasattr(self, 'main_text'):
+            raise NotImplementedError(
+                'Child class must implement the self.main_text attribute to'
+                'use this method.')
+
+        text = html.Div([text])
+        self.main_text.append(text)
+
+    def add_collapsed_text(self, text, title='More details...'):
+        """Add a block of text at the top of the app.
+
+        By default, this text will be hidden. The user can click on a button
+        with the specified title in order to view the text.
+
+        Parameters
+        ----------
+        text : str
+            The text to add to the html div
+        title : str
+            str which will be displayed on the show/hide button
+        """
+        if not hasattr(self, 'collapsed_text'):
+            raise NotImplementedError(
+                'Child class must implement the self.collapsed_text attribute'
+                'to use this method.')
+
         collapse = html.Div([
                 dbc.Button(
                     title,
@@ -170,4 +199,4 @@ class BranchProDashApp:
                     id='collapsedtext',
                 ),
             ])
-        self.collapsed_text = collapse
+        self.collapsed_text.append(collapse)

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -7,6 +7,7 @@
 # notice and full license details.
 #
 
+import threading
 import base64
 import io
 import os
@@ -64,6 +65,8 @@ class BranchProDashApp:
         self.mathjax_html = index_str_math
         self.mathjax_script = mathjax_script
 
+        self.lock = threading.Lock()
+
     def refresh_user_data_json(self, **kwargs):
         """Load the user's session data from JSON.
 
@@ -81,6 +84,7 @@ class BranchProDashApp:
             by the particular app, and each value should be a string containing
             the JSON data accessed from that storage.
         """
+        # with self.lock:
         self.new_session_data = {}
         for k, v in kwargs.items():
             if v is not None:

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -59,8 +59,7 @@ class BranchProDashApp:
     Notes
     -----
     When deploying objects of this class in a server environment, it is
-    recommended to use the lock to prevent unpleasant bugs and interference
-    between threads:
+    recommended to use the lock to prevent interference between threads.
 
     .. code-block:: python
 

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -14,6 +14,10 @@ class BranchProDashApp:
     """Base class for dash apps for branching processes.
     """
     def __init__(self):
+        # Default CSS styles
+        self.css = [dbc.themes.BOOTSTRAP,
+                    'https://codepen.io/chriddyp/pen/bWLwgP.css']
+
         self.session_data = {}
 
     def refresh_user_data_json(self, **kwargs):

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -16,8 +16,8 @@ class BranchProDashApp:
     def __init__(self):
         self.session_data = {}
 
-    def refresh_user_data(self, **kwargs):
-        """Load the user's session data.
+    def refresh_user_data_json(self, **kwargs):
+        """Load the user's session data from JSON.
 
         To be called at the beginning of an HTTP request so that this object
         contains the appropriate information for completing the request.
@@ -29,9 +29,9 @@ class BranchProDashApp:
         Parameters
         ----------
         kwargs
-            Each key should be the id of a storage HTML div recognized by the
-            particular app, and each value should be a string containing the
-            JSON data accessed from that container.
+            Each key should be the id or name of a storage container recognized
+            by the particular app, and each value should be a string containing
+            the JSON data accessed from that storage.
         """
         self.session_data = {}
         for k, v in kwargs.items():

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -8,7 +8,44 @@
 #
 
 import pandas as pd
+import dash_defer_js_import as dji  # For mathjax
 import dash_bootstrap_components as dbc
+
+
+# Import the mathjax
+mathjax_script = dji.Import(
+    src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/latest.js'
+        '?config=TeX-AMS-MML_SVG')
+
+
+# Write the mathjax index html
+# https://chrisvoncsefalvay.com/2020/07/25/dash-latex/
+index_str_math = """<!DOCTYPE html>
+<html>
+    <head>
+        {%metas%}
+        <title>{%title%}</title>
+        {%favicon%}
+        {%css%}
+    </head>
+    <body>
+        {%app_entry%}
+        <footer>
+            {%config%}
+            {%scripts%}
+            <script type="text/x-mathjax-config">
+            MathJax.Hub.Config({
+                tex2jax: {
+                inlineMath: [ ['$','$'],],
+                processEscapes: true
+                }
+            });
+            </script>
+            {%renderer%}
+        </footer>
+    </body>
+</html>
+"""
 
 
 class BranchProDashApp:
@@ -20,6 +57,8 @@ class BranchProDashApp:
                     'https://codepen.io/chriddyp/pen/bWLwgP.css']
 
         self.session_data = {}
+        self.mathjax_html = index_str_math
+        self.mathjax_script = mathjax_script
 
     def refresh_user_data_json(self, **kwargs):
         """Load the user's session data from JSON.

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -62,11 +62,13 @@ class BranchProDashApp:
     recommended to use the lock to prevent unpleasant bugs and interference
     between threads:
 
-    >>> @app.app.callback(...)
-    >>> def callback(...):
-    >>>     with app.lock:
-    >>>         ...  # your callback code here
-    >>>         return ...
+    .. code-block:: python
+
+        @app.app.callback(...)
+        def callback(...):
+            with app.lock:
+                ...  # your callback code here
+                return ...
     """
     def __init__(self):
         # Default CSS style files

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -55,9 +55,21 @@ index_str_math = """<!DOCTYPE html>
 
 class BranchProDashApp:
     """Base class for dash apps for branching processes.
+
+    Notes
+    -----
+    When deploying objects of this class in a server environment, it is
+    recommended to use the lock to prevent unpleasant bugs and interference
+    between threads:
+
+    >>> @app.app.callback(...)
+    >>> def callback(...):
+    >>>     with app.lock:
+    >>>         ...  # your callback code here
+    >>>         return ...
     """
     def __init__(self):
-        # Default CSS styles
+        # Default CSS style files
         self.css = [dbc.themes.BOOTSTRAP,
                     'https://codepen.io/chriddyp/pen/bWLwgP.css']
 
@@ -70,7 +82,7 @@ class BranchProDashApp:
     def refresh_user_data_json(self, **kwargs):
         """Load the user's session data from JSON.
 
-        To be called at the beginning of an HTTP request so that this object
+        To be called at the beginning of a callback so that this object
         contains the appropriate information for completing the request.
 
         The inputs are translated from JSON to pandas dataframes, and saved in
@@ -84,7 +96,6 @@ class BranchProDashApp:
             by the particular app, and each value should be a string containing
             the JSON data accessed from that storage.
         """
-        # with self.lock:
         self.new_session_data = {}
         for k, v in kwargs.items():
             if v is not None:
@@ -139,9 +150,13 @@ class BranchProDashApp:
             return html.Div(['Loaded data from: {}'.format(filename)]), df
 
     def _load_text(self, text):
+        """Load text into an HTML div saved at self.text.
+        """
         self.text = html.Div([text])
 
     def _load_collapsed_text(self, text, title):
+        """Load text into a hidden HTML div with button at self.collapsed_text.
+        """
         collapse = html.Div([
                 dbc.Button(
                     title,
@@ -154,38 +169,3 @@ class BranchProDashApp:
                 ),
             ])
         self.collapsed_text = collapse
-
-    def add_text(self, text):
-        """Add a block of text at the top of the app.
-
-        This can be used to add introductory text that everyone looking at the
-        app will see right away.
-
-        Child classes should override this method with one that places the text
-        into their layout.
-
-        Parameters
-        ----------
-        text : str
-            The text to add to the html div
-        """
-        raise NotImplementedError
-
-    def add_collapsed_text(self, text, title='More details...'):
-        """Add a block of text at the top of the app.
-
-        By default, this text will be hidden. The user can click on a button
-        with the specified title in order to view the text.
-
-        This method saves the text in an HTML div at self.collapsed_text. Child
-        classes should override this method with one that places the text into
-        the layout.
-
-        Parameters
-        ----------
-        text : str
-            The text to add to the html div
-        title : str
-            str which will be displayed on the show/hide button
-        """
-        raise NotImplementedError

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -7,6 +7,9 @@
 # notice and full license details.
 #
 
+import base64
+import io
+import os
 import pandas as pd
 import dash_defer_js_import as dji  # For mathjax
 import dash_bootstrap_components as dbc
@@ -89,6 +92,10 @@ class BranchProDashApp:
 
         Parameters
         ----------
+        contents : str
+            File contents in binary encoding
+        filename : str
+            Name of the file
 
         Returns
         -------

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -96,12 +96,12 @@ class BranchProDashApp:
             by the particular app, and each value should be a string containing
             the JSON data accessed from that storage.
         """
-        self.new_session_data = {}
+        new_session_data = {}
         for k, v in kwargs.items():
             if v is not None:
                 v = pd.read_json(v)
-            self.new_session_data[k] = v
-        self.session_data = self.new_session_data
+            new_session_data[k] = v
+        self.session_data = new_session_data
 
     def parse_contents(self, contents, filename):
         """Load a text (csv) file into a pandas dataframe.

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -1,0 +1,38 @@
+#
+# BranchProDashApp Class
+#
+# This file is part of BRANCHPRO
+# (https://github.com/SABS-R3-Epidemiology/branchpro.git) which is released
+# under the BSD 3-clause license. See accompanying LICENSE.md for copyright
+# notice and full license details.
+#
+
+
+class BranchProDashApp:
+    """Base class for dash apps for branching processes.
+    """
+    def __init__(self):
+        self.session_data = {}
+
+    def refresh_user_data(self, **kwargs):
+        """Load the user's session data.
+
+        To be called at the beginning of an HTTP request so that this object
+        contains the appropriate information for completing the request.
+
+        The inputs are translated from JSON to pandas dataframes, and saved in
+        the self.session_data dictionary. All previous entries in
+        self.session_data are cleared.
+
+        Parameters
+        ----------
+        kwargs
+            Each key should be the id of a storage HTML div recognized by the
+            particular app, and each value should be a string containing the
+            JSON data accessed from that container.
+        """
+        self.session_data = {}
+        for k, v in kwargs.items():
+            if v is not None:
+                v = pd.read_json(v)
+            self.session_data[k] = v

--- a/branchpro/apps/_dash_app.py
+++ b/branchpro/apps/_dash_app.py
@@ -10,6 +10,7 @@
 import pandas as pd
 import dash_defer_js_import as dji  # For mathjax
 import dash_bootstrap_components as dbc
+import dash_html_components as html
 
 
 # Import the mathjax
@@ -82,3 +83,93 @@ class BranchProDashApp:
             if v is not None:
                 v = pd.read_json(v)
             self.session_data[k] = v
+
+    def parse_contents(self, contents, filename):
+        """Load a text (csv) file into a pandas dataframe.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        html Div
+            A div which contains a message for the user.
+        pandas.DataFrame
+            A dataframe with the loaded file. If the file load was not
+            successful, it will be None.
+        """
+        content_type, content_string = contents.split(',')
+        _, extension = os.path.splitext(filename)
+
+        decoded = base64.b64decode(content_string)
+        try:
+            if extension in ['.csv', '.txt']:
+                # Assume that the user uploaded a CSV or TXT file
+                df = pd.read_csv(
+                    io.StringIO(decoded.decode('utf-8')))
+            else:
+                return html.Div(['File type must be CSV or TXT.']), None
+        except Exception as e:
+            print(e)
+            return html.Div([
+                'There was an error processing this file.'
+            ]), None
+
+        if ('Time' not in df.columns) or (
+                'Incidence Number' not in df.columns):
+            return html.Div(['Incorrect format; file must contain a `Time` \
+                and `Incidence Number` column.']), None
+        else:
+            return html.Div(['Loaded data from: {}'.format(filename)]), df
+
+    def _load_text(self, text):
+        self.text = html.Div([text])
+
+    def _load_collapsed_text(self, text, title):
+        collapse = html.Div([
+                dbc.Button(
+                    title,
+                    id='showhidebutton',
+                    color='primary',
+                ),
+                dbc.Collapse(
+                    dbc.Card(dbc.CardBody(text)),
+                    id='collapsedtext',
+                ),
+            ])
+        self.collapsed_text = collapse
+
+    def add_text(self, text):
+        """Add a block of text at the top of the app.
+
+        This can be used to add introductory text that everyone looking at the
+        app will see right away.
+
+        Child classes should override this method with one that places the text
+        into their layout.
+
+        Parameters
+        ----------
+        text : str
+            The text to add to the html div
+        """
+        raise NotImplementedError
+
+    def add_collapsed_text(self, text, title='More details...'):
+        """Add a block of text at the top of the app.
+
+        By default, this text will be hidden. The user can click on a button
+        with the specified title in order to view the text.
+
+        This method saves the text in an HTML div at self.collapsed_text. Child
+        classes should override this method with one that places the text into
+        the layout.
+
+        Parameters
+        ----------
+        text : str
+            The text to add to the html div
+        title : str
+            str which will be displayed on the show/hide button
+        """
+        raise NotImplementedError

--- a/branchpro/apps/_inference.py
+++ b/branchpro/apps/_inference.py
@@ -8,7 +8,6 @@
 #
 from math import floor
 
-import pandas as pd
 import dash
 import dash_bootstrap_components as dbc
 import dash_core_components as dcc
@@ -31,15 +30,6 @@ class BranchProInferenceApp(BranchProDashApp):
 
         self.session_data = {'data_storage': None, 'posterior_storage': None}
 
-        self.plot1 = bp.IncidenceNumberPlot()
-        self.plot2 = bp.ReproductionNumberPlot()
-
-        # Keeps traces visibility states fixed when changing sliders
-        # in the second figure
-        self.plot2.figure['layout']['legend']['uirevision'] = True
-
-        self.sliders = bp._SliderComponent()
-
         self.app.layout = html.Div([
             dbc.Container(
                 [
@@ -48,13 +38,15 @@ class BranchProInferenceApp(BranchProDashApp):
                     html.H2('Incidence Data'),
                     dbc.Row(
                         dbc.Col(dcc.Graph(
-                                figure=self.plot1.figure, id='fig1'))
+                                figure=bp.IncidenceNumberPlot().figure,
+                                id='data-fig'))
                     ),
                     html.H2('Plot of R values'),
                     dbc.Row(
                         [
                             dbc.Col(dcc.Graph(
-                                figure=self.plot2.figure, id='fig2')),
+                                figure=bp.ReproductionNumberPlot().figure,
+                                id='posterior-fig')),
                             dbc.Col(self.update_sliders())
                         ],
                         align='center',
@@ -130,14 +122,13 @@ class BranchProInferenceApp(BranchProDashApp):
         """
         data = self.session_data['data_storage']
         if data is not None:
-            times = data['Time']
+            time_label, inc_label = data.columns[:2]
+            times = data[time_label]
             max_tau = floor(times.max() - times.min() + 1)/3
         else:
             max_tau = 7
 
-        # Make new sliders
         sliders = bp._SliderComponent()
-
         sliders.add_slider(
             'Prior Mean', 'mean', mean, 0.1, 10.0, 0.01)
         sliders.add_slider(
@@ -152,165 +143,89 @@ class BranchProInferenceApp(BranchProDashApp):
         return sliders.get_sliders_div()
 
     def update_posterior(self, mean, stdev, tau, central_prob):
+        """Update the posterior distribution based on slider values.
+
+        Parameters
+        ----------
+        mean
+            (float) updated position on the slider for the mean of
+            the prior for the Branch Pro model in the posterior.
+        stdev
+            (float) updated position on the slider for the standard deviation
+            of the prior for the Branch Pro model in the posterior.
+        tau
+            (int) updated position on the slider for the tau window used in the
+            running of the inference of the reproduction numbers of the Branch
+            Pro model in the posterior.
+        central_prob
+            (float) updated position on the slider for the level of the
+            computed credible interval of the estimated R number values.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The posterior distribution, summarized in a dataframe with the
+            following columns: 'Time Points', 'Mean', 'Lower bound CI' and
+            'Upper bound CI'
+        """
         new_alpha = (mean / stdev) ** 2
         new_beta = mean / (stdev ** 2)
-        new_prior_parameters = (new_alpha, new_beta)
 
         data = self.session_data['data_storage']
+        time_label, inc_label = data.columns[:2]
 
         posterior = bp.BranchProPosterior(
-            data, self.serial_interval, new_alpha, new_beta, time_key='Days')
+            data,
+            self.serial_interval,
+            new_alpha,
+            new_beta,
+            time_key=time_label,
+            inc_key=inc_label)
 
         posterior.run_inference(tau)
-        df = posterior.get_intervals(central_prob)
-
-        return df
+        return posterior.get_intervals(central_prob)
 
     def update_inference_figure(self):
+        """Update the inference figure based on currently stored information.
+
+        Returns
+        -------
+        plotly.Figure
+            Figure with updated posterior distribution
+        """
         data = self.session_data['data_storage']
         posterior = self.session_data['posterior_storage']
+        time_label, inc_label = data.columns[:2]
 
         plot = bp.ReproductionNumberPlot()
         plot.add_interval_rt(posterior)
 
         if 'R_t' in data.columns:
-            plot.add_ground_truth_rt(data[['Days', 'R_t']], time_key='Days', r_key='R_t')
+            plot.add_ground_truth_rt(
+                data[[time_label, 'R_t']],
+                time_key=time_label,
+                r_key='R_t')
+
+        # Keeps traces visibility states fixed when changing sliders
+        plot.figure['layout']['legend']['uirevision'] = True
 
         return plot.figure
 
-    def add_ground_truth_rt(self, df, time_label='Time Points', r_label='R_t'):
+    def update_data_figure(self):
+        """Update the data figure based on currently stored information.
+
+        Returns
+        -------
+        plotly.Figure
+            Figure with updated data
         """
-        Adds incidence data to the plot in the dash app.
+        data = self.session_data['data_storage']
+        time_label, inc_label = data.columns[:2]
 
-        Parameters
-        ----------
-        df
-            (pandas DataFrame) contains the true values of the reproduction
-            number by time unit. Data stored in columns of time and
-            reproduction number, respectively.
-        time_label
-            label key given to the temporal data in the dataframe.
-        r_label
-            label key given to the reproduction number data in the dataframe.
-        """
-        self.plot2.add_ground_truth_rt(df, time_key=time_label, r_key=r_label)
+        plot = bp.IncidenceNumberPlot()
+        plot.add_data(data, time_key=time_label, inc_key=inc_label)
 
-    def add_posterior(self,
-                      posterior,
-                      mean=5.0,
-                      stdev=5.0,
-                      tau=6,
-                      central_prob=.95):
-        """
-        Computes the posterior probability of some instances dataframe, infers
-        reproduction numbers with quantiles, them as lines to the second
-        plot and adds sliders to the app.
+        # Keeps traces visibility states fixed when changing sliders
+        plot.figure['layout']['legend']['uirevision'] = True
 
-        Parameters
-        ----------
-        posterior
-            (BranchProPosterior) a dataframe of instances and the parameters of
-            the prior used to infer the reproduction numbers of a BranchPro
-            model used to model the data.
-        mean
-            (float) start position on the slider for the mean of the
-            prior for the Branch Pro model in the posterior.
-        stdev
-            (float) start position on the slider for the standard deviation of
-            the prior for the Branch Pro model in the posterior.
-        tau
-            (int) start position on the slider for the tau window used in the
-            running of the inference of the reproduction numbers of the Branch
-            Pro model in the posterior.
-        central_prob
-            (float) start position on the slider for the level of the computed
-            credible interval of the estimated R number values.
-        """
-        if not issubclass(type(posterior), bp.BranchProPosterior):
-            raise TypeError('Posterior needs to be a BranchProPosterior')
-
-        fig1_labels = posterior.cases_labels
-
-        df1 = pd.DataFrame({
-            fig1_labels[0]: posterior.cases_times,
-            fig1_labels[1]: posterior.cases_data})
-
-        max_tau = floor(
-            posterior.cases_times.max() - posterior.cases_times.min() + 1)/3
-
-        self.sliders.add_slider(
-            'Prior Mean', 'mean', mean, 0.1, 10.0, 0.01)
-        self.sliders.add_slider(
-            'Prior Standard Deviation', 'stdev', stdev, 0.1, 10.0, 0.01)
-        self.sliders.add_slider(
-            'Inference Sliding Window', 'tau', tau, 0, max_tau, 1,
-            as_integer=True)
-        self.sliders.add_slider(
-            'Central Posterior Probability', 'central_prob', central_prob, 0.1,
-            0.99, 0.01)
-
-        alpha = (mean/stdev)**2
-        beta = mean/(stdev**2)
-        prior_parameters = (alpha, beta)
-        posterior.prior_parameters = prior_parameters
-
-        posterior.run_inference(tau)
-        df2 = posterior.get_intervals(central_prob)
-
-        self.plot1.add_data(
-            df1, time_key=fig1_labels[0], inc_key=fig1_labels[1])
-        self.plot2.add_interval_rt(df2)
-
-        self.posterior = posterior
-
-        # Save the infered figure for later update
-        self._graph = self.plot2.figure['data'][-1]
-        self._graph_mean = self.plot2.figure['data'][-2]
-
-    def update_inference(
-            self, new_mean, new_stdev, new_tau, new_central_prob):
-        """
-        Updates the parameters in the inference and the estimated reproduction
-        numbers and quantiles graph in the second figure.
-
-        Parameters
-        ----------
-        new_mean
-            (float) updated position on the slider for the mean of
-            the prior for the Branch Pro model in the posterior.
-        new_stdev
-            (float) updated position on the slider for the standard deviation
-            of the prior for the Branch Pro model in the posterior.
-        new_tau
-            (int) updated position on the slider for the tau window used in the
-            running of the inference of the reproduction numbers of the Branch
-            Pro model in the posterior.
-        new_central_prob
-            (float) start position on the slider for the level of the computed
-            credible interval of the estimated R number values.
-        """
-        new_alpha = (new_mean/new_stdev)**2
-        new_beta = new_mean/(new_stdev**2)
-        new_prior_parameters = (new_alpha, new_beta)
-
-        self.posterior.prior_parameters = new_prior_parameters
-
-        self.posterior.run_inference(new_tau)
-        df = self.posterior.get_intervals(new_central_prob)
-
-        time_key = 'Time Points'
-        ur_key = 'Upper bound CI'
-        lr_key = 'Lower bound CI'
-        cp_key = 'Central Probability'
-        new_x = list(df[time_key]) + list(df[time_key])[::-1]
-        new_y = list(df[ur_key]) + list(df[lr_key])[::-1]
-
-        self._graph['x'] = new_x
-        self._graph['y'] = new_y
-
-        self._graph_mean['x'] = df[time_key]
-        self._graph_mean['y'] = df['Mean']
-
-        self._graph['name'] = 'Credible interval ' + str(df[cp_key][0])
-
-        return self.plot2.figure
+        return plot.figure

--- a/branchpro/apps/_inference.py
+++ b/branchpro/apps/_inference.py
@@ -120,7 +120,7 @@ class BranchProInferenceApp(BranchProDashApp):
         html.Div
             A dash html component containing the sliders
         """
-        data = self.session_data['data_storage']
+        data = self.session_data.get('data_storage'])
         if data is not None:
             time_label, inc_label = data.columns[:2]
             times = data[time_label]
@@ -171,7 +171,11 @@ class BranchProInferenceApp(BranchProDashApp):
         new_alpha = (mean / stdev) ** 2
         new_beta = mean / (stdev ** 2)
 
-        data = self.session_data['data_storage']
+        data = self.session_data.get('data_storage')
+
+        if data is None:
+            raise dash.exceptions.PreventUpdate()
+
         time_label, inc_label = data.columns[:2]
 
         posterior = bp.BranchProPosterior(
@@ -193,8 +197,12 @@ class BranchProInferenceApp(BranchProDashApp):
         plotly.Figure
             Figure with updated posterior distribution
         """
-        data = self.session_data['data_storage']
-        posterior = self.session_data['posterior_storage']
+        data = self.session_data.get('data_storage')
+        posterior = self.session_data.get('posterior_storage')
+
+        if data is None or posterior is None:
+            raise dash.exceptions.PreventUpdate()
+
         time_label, inc_label = data.columns[:2]
 
         plot = bp.ReproductionNumberPlot()
@@ -219,7 +227,11 @@ class BranchProInferenceApp(BranchProDashApp):
         plotly.Figure
             Figure with updated data
         """
-        data = self.session_data['data_storage']
+        data = self.session_data.get('data_storage')
+
+        if data is None:
+            raise dash.exceptions.PreventUpdate()
+
         time_label, inc_label = data.columns[:2]
 
         plot = bp.IncidenceNumberPlot()

--- a/branchpro/apps/_inference.py
+++ b/branchpro/apps/_inference.py
@@ -120,7 +120,7 @@ class BranchProInferenceApp(BranchProDashApp):
         html.Div
             A dash html component containing the sliders
         """
-        data = self.session_data.get('data_storage'])
+        data = self.session_data.get('data_storage')
         if data is not None:
             time_label, inc_label = data.columns[:2]
             times = data[time_label]

--- a/branchpro/apps/_inference.py
+++ b/branchpro/apps/_inference.py
@@ -61,36 +61,9 @@ class BranchProInferenceApp(BranchProDashApp):
         # Set the app index string for mathjax
         self.app.index_string = self.mathjax_html
 
-    def add_text(self, text):
-        """Add a block of text at the top of the app.
-
-        This can be used to add introductory text that everyone looking at the
-        app will see right away.
-
-        Parameters
-        ----------
-        text : str
-            The text to add to the html div
-        """
-        self._load_text(text)
-        self.app.layout.children[0].children[1].children.append(self.text)
-
-    def add_collapsed_text(self, text, title='More details...'):
-        """Add a block of text at the top of the app.
-
-        By default, this text will be hidden. The user can click on a button
-        with the specified title in order to view the text.
-
-        Parameters
-        ----------
-        text : str
-            The text to add to the html div
-        title : str
-            str which will be displayed on the show/hide button
-        """
-        self._load_collapsed_text(text, title)
-        self.app.layout.children[0].children[-3].children.append(
-            self.collapsed_text)
+        # Save the locations of texts from the layout
+        self.main_text = self.app.layout.children[0].children[1].children
+        self.collapsed_text = self.app.layout.children[0].children[-3].children
 
     def update_sliders(self,
                        mean=5.0,

--- a/branchpro/apps/_reproduction_number_plot.py
+++ b/branchpro/apps/_reproduction_number_plot.py
@@ -105,7 +105,7 @@ class ReproductionNumberPlot():
             fillcolor='indigo',
             line_color='indigo',
             opacity=0.5,
-            name='Credible interval ' + str(df[cp_key][0]),
+            name='Credible interval {:.8f}'.format(df[cp_key][0]).rstrip('0'),
         )
 
         self.figure.add_trace(trace1)

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -153,8 +153,9 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
             Figure with updated data and simulations
         """
         data = self.session_data['data_storage']
-        time_label, inc_label = data.columns
         simulations = self.session_data['sim_storage']
+
+        time_label, inc_label = data.columns
         num_simulations = len(simulations.columns) - 1
 
         plot = bp.IncidenceNumberPlot()
@@ -164,12 +165,8 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         plot.figure['layout']['legend']['uirevision'] = True
 
         for sim in range(num_simulations):
-            # plot.add_simulation(
-                # simulations[['Time', 'sim{}'.format(sim + 1)]])
-            df = pd.DataFrame(
-                {time_label: simulations[time_label],
-                 inc_label: simulations['sim{}'.format(sim + 1)]
-                 })
+            df = simulations[[time_label, 'sim{}'.format(sim + 1)]]
+            df.columns = [time_label, inc_label]
             plot.add_simulation(df, time_key=time_label, inc_key=inc_label)
 
             # Unless it is the most recent simulation, decrease the opacity to
@@ -185,6 +182,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         """
         sim = self.session_data['sim_storage']
         data = self.session_data['data_storage']
+
         time_label, inc_label = data.columns
 
         # Only attempt the purge if there is data there
@@ -224,8 +222,9 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
             Simulations storage dataframe in JSON format
         """
         data = self.session_data['data_storage']
-        time_label, inc_label = data.columns
         simulations = self.session_data['sim_storage']
+
+        time_label, inc_label = data.columns
         times = data[time_label]
 
         # There might be no simulation data if it got just cleared, or this is

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -122,6 +122,66 @@ class IncidenceNumberSimulationApp:
         # Set the app index string for mathjax
         self.app.index_string = 'fix this'
 
+    def update_sliders(self,
+                       init_cond=10.0,
+                       r0=2.0,
+                       r1=0.5,
+                       magnitude_init_cond=None):
+        """Generate sliders for the app.
+
+        This method tunes the bounds of the sliders to the time period and
+        magnitude of the data.
+
+        Parameters
+        ----------
+        init_cond : int
+            start position on the slider for the number of initial cases for
+            the Branch Pro model in the simulator.
+        r0 : float
+            start position on the slider for the initial reproduction number
+            for the Branch Pro model in the simulator.
+        r1 : float
+            start position on the slider for the second reproduction number for
+            the Branch Pro model in the simulator.
+        magnitude_init_cond : int
+            maximal start position on the slider for the number of initial
+            cases for the Branch Pro model in the simulator. By default, it
+            will be set to the maximum value observed in the data.
+
+        Returns
+        -------
+        html.Div
+            A dash html component containing the sliders
+        """
+        data = self.session_data['data_storage']
+
+        # Calculate slider values that depend on the data
+        if data is not None:
+            if magnitude_init_cond is None:
+                magnitude_init_cond = max(data['Incidence Number'])
+            bounds = (1, max(data['Time']))
+
+        else:
+            # choose values to use if there is no data
+            if magnitude_init_cond is None:
+                magnitude_init_cond = 10
+            bounds = (1, 30)
+
+        mid_point = round(sum(bounds) / 2)
+
+        # Make new sliders
+        sliders = bp._SliderComponent()
+        sliders.add_slider(
+            'Initial Cases', 'init_cond', init_cond, 0.0, magnitude_init_cond,
+            1, as_integer=True)
+        sliders.add_slider('Initial R', 'r0', r0, 0.1, 10.0, 0.01)
+        sliders.add_slider('Second R', 'r1', r1, 0.1, 10.0, 0.01)
+        sliders.add_slider(
+            'Time of change', 't1', mid_point, bounds[0], bounds[1], 1,
+            as_integer=True)
+
+        return sliders.get_sliders_div()
+
     def add_text(self, text):
         """Add a block of text at the top of the app.
 

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -182,6 +182,35 @@ class IncidenceNumberSimulationApp:
 
         return sliders.get_sliders_div()
 
+    def update_figure(self):
+        """Generate a plotly figure of incidence numbers and simulated cases.
+
+        Returns
+        -------
+        plotly.Figure
+            Figure with updated data and simulations
+        """
+        data = self.session_data['data_storage']
+        simulations = self.session_data['sim_storage']
+        num_simulations = len(simulations.columns) - 1
+
+        plot = bp.IncidenceNumberPlot()
+        plot.add_data(data)
+
+        # Keeps traces visibility states fixed when changing sliders
+        plot.figure['layout']['legend']['uirevision'] = True
+
+        for sim in range(num_simulations):
+            plot.add_simulation(simulations[['Time', 'sim{}'.format(sim + 1)]])
+
+            # Unless it is the most recent simulation, decrease the opacity to
+            # 25% and remove it from the legend
+            if sim < num_simulations - 1:
+                plot.figure['data'][-1]['line'].color = 'rgba(255,0,0,0.25)'
+                plot.figure['data'][-1]['showlegend'] = False
+
+        return plot.figure
+
     def add_text(self, text):
         """Add a block of text at the top of the app.
 

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -20,6 +20,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 
 import branchpro as bp
+from branchpro.apps import BranchProDashApp
 
 
 # Import the mathjax
@@ -57,7 +58,7 @@ index_str_math = """<!DOCTYPE html>
 """
 
 
-class IncidenceNumberSimulationApp:
+class IncidenceNumberSimulationApp(BranchProDashApp):
     """IncidenceNumberSimulationApp Class:
     Class for the simulation dash app with figure and sliders for the
     BranchPro models.
@@ -116,11 +117,11 @@ class IncidenceNumberSimulationApp:
                     html.Div(id='data_storage', style={'display': 'none'}),
                     html.Div(id='sim_storage', style={'display': 'none'})
                     ], fluid=True),
-                mathjax_script
+                self.mathjax_script
                 ])
 
         # Set the app index string for mathjax
-        self.app.index_string = 'fix this'
+        self.app.index_string = self.mathjax_html
 
     def update_sliders(self,
                        init_cond=10.0,

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -87,37 +87,37 @@ class IncidenceNumberSimulationApp:
                         dbc.Col(
                             self.update_sliders(), id='all-sliders')
                     ], align='center'),
-                html.H4([
-                    'You can upload your own incidence data here. It will'
-                    'appear as bars, while the simulation will be a line.'
-                ]),
-                dcc.Upload(
-                    id='upload-data',
-                    children=html.Div([
-                        'Drag and Drop or ',
-                            html.A('Select Files',
-                                style={'text-decoration': 'underline'}),
-                        ' to upload your Incidence Number data.'
+                    html.H4([
+                        'You can upload your own incidence data here. It will'
+                        'appear as bars, while the simulation will be a line.'
                     ]),
-                    style={
-                        'width': '100%',
-                        'height': '60px',
-                        'lineHeight': '60px',
-                        'borderWidth': '1px',
-                        'borderStyle': 'dashed',
-                        'borderRadius': '5px',
-                        'textAlign': 'center',
-                        'margin': '10px'
-                    },
-                    multiple=True  # Allow multiple files to be uploaded
-                ),
-                html.Div(id='incidence-data-upload'),
-                html.Div([]), # Empty div for bottom text
-                html.Div(id='data_storage', style={'display': 'none'}),
-                html.Div(id='sim_storage', style={'display': 'none'})
-                ], fluid=True),
-            mathjax_script
-            ])
+                    dcc.Upload(
+                        id='upload-data',
+                        children=html.Div([
+                            'Drag and Drop or ',
+                            html.A('Select Files',
+                                   style={'text-decoration': 'underline'}),
+                            ' to upload your Incidence Number data.'
+                        ]),
+                        style={
+                            'width': '100%',
+                            'height': '60px',
+                            'lineHeight': '60px',
+                            'borderWidth': '1px',
+                            'borderStyle': 'dashed',
+                            'borderRadius': '5px',
+                            'textAlign': 'center',
+                            'margin': '10px'
+                        },
+                        multiple=True  # Allow multiple files to be uploaded
+                    ),
+                    html.Div(id='incidence-data-upload'),
+                    html.Div([]),  # Empty div for bottom text
+                    html.Div(id='data_storage', style={'display': 'none'}),
+                    html.Div(id='sim_storage', style={'display': 'none'})
+                    ], fluid=True),
+                mathjax_script
+                ])
 
         # Set the app index string for mathjax
         self.app.index_string = 'fix this'

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -76,7 +76,6 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
                     html.Div(id='incidence-data-upload'),
                     html.Div([]),  # Empty div for bottom text
                     html.Div(id='data_storage', style={'display': 'none'}),
-                    html.Div(id='sim_storage', style={'display': 'none'})
                     ], fluid=True),
                 self.mathjax_script
                 ])
@@ -86,7 +85,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
 
         # Save the locations of texts from the layout
         self.main_text = self.app.layout.children[0].children[1].children
-        self.collapsed_text = self.app.layout.children[0].children[-3].children
+        self.collapsed_text = self.app.layout.children[0].children[-2].children
 
     def update_sliders(self,
                        init_cond=10.0,

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -74,6 +74,8 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
                     ),
                     html.Div(id='incidence-data-upload'),
                     html.Div([]),  # Empty div for bottom text
+                    # dcc.Store(id='data_storage'),
+                    # dcc.Store(id='sim_storage')
                     html.Div(id='data_storage', style={'display': 'none'}),
                     html.Div(id='sim_storage', style={'display': 'none'})
                     ], fluid=True),
@@ -180,8 +182,15 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
     def clear_simulations(self):
         """Remove all previous simulations from sim storage.
         """
-        sim = self.session_data['sim_storage']
-        data = self.session_data['data_storage']
+        try:
+            sim = self.session_data['sim_storage']
+            k = self.session_data.keys()
+            data = self.session_data['data_storage']
+        except KeyError:
+            print(self.session_data)
+            print(k)
+            print('\n\n\n\n')
+            raise KeyError
 
         time_label, inc_label = data.columns
 

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -351,8 +351,8 @@ class IncidenceNumberSimulationApp:
         str
             Simulations storage dataframe in JSON format
         """
-        data = self.session_data['data-storage']
-        simulations = self.session_data['sim-storage']
+        data = self.session_data['data_storage']
+        simulations = self.session_data['sim_storage']
         times = data['Time']
 
         # Add the correct R profile to the branchpro model

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -7,6 +7,8 @@
 # notice and full license details.
 #
 
+# import threading
+
 import numpy as np
 import pandas as pd
 import dash
@@ -25,6 +27,9 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
     """
     def __init__(self):
         super().__init__()
+
+        # self.lock = threading.Lock()
+
         self.session_data = {'data_storage': None, 'sim_storage': None}
 
         self.app = dash.Dash(__name__, external_stylesheets=self.css)
@@ -227,8 +232,8 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
 
         Returns
         -------
-        str
-            Simulations storage dataframe in JSON format
+        pandas.DataFrame
+            Simulations storage dataframe
         """
         data = self.session_data['data_storage']
         simulations = self.session_data['sim_storage']
@@ -254,7 +259,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         num_sims = len(simulations.columns)
         simulations['sim{}'.format(num_sims)] = data
 
-        return simulations.to_json()
+        return simulations
 
     def add_data(
             self, df=None, time_label='Time', inc_label='Incidence Number'):

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -63,16 +63,11 @@ class IncidenceNumberSimulationApp:
     BranchPro models.
     """
     def __init__(self):
-        self.app = dash.Dash(
-             __name__, external_stylesheets=[
-                dbc.themes.BOOTSTRAP,
-                'https://codepen.io/chriddyp/pen/bWLwgP.css'])
-        self.app.title = 'BranchproSim'
-        self.plot = bp.IncidenceNumberPlot()
+        super().__init__()
+        self.session_data = {'data_storage': None, 'sim_storage': None}
 
-        # Keeps traces visibility states fixed when changing sliders
-        self.plot.figure['layout']['legend']['uirevision'] = True
-        self.sliders = bp._SliderComponent()
+        self.app = dash.Dash(__name__, external_stylesheets=self.css)
+        self.app.title = 'BranchproSim'
 
         self.app.layout = \
             html.Div([
@@ -85,46 +80,47 @@ class IncidenceNumberSimulationApp:
                                 'Add new simulation',
                                 id='sim-button',
                                 n_clicks=0),
-                            dcc.Graph(figure=self.plot.figure, id='myfig')]
-                            ),
-                        dbc.Col(
-                            self.sliders.get_sliders_div(), id='all-sliders')
-                            ],
-                            align='center'
-                            ),
-                    html.H4(['You can upload your own incidence data here. It \
-                        will appear as bars, while the simulation will be a \
-                        line.']),
-                    dcc.Upload(
-                        id='upload-data',
-                        children=html.Div([
-                            'Drag and Drop or ',
-                            html.A(
-                                'Select Files',
-                                style={'text-decoration': 'underline'}),
-                            ' to upload your Incidence Number data.'
+                            dcc.Graph(
+                                figure=bp.IncidenceNumberPlot().figure,
+                                id='myfig')
                         ]),
-                        style={
-                            'width': '100%',
-                            'height': '60px',
-                            'lineHeight': '60px',
-                            'borderWidth': '1px',
-                            'borderStyle': 'dashed',
-                            'borderRadius': '5px',
-                            'textAlign': 'center',
-                            'margin': '10px'
-                        },
-                        # Allow multiple files to be uploaded
-                        multiple=True
-                    ),
-                    html.Div(id='incidence-data-upload'),
-                    html.Div([])], fluid=True),  # Empty div for bottom text
-                mathjax_script])
+                        dbc.Col(
+                            self.update_sliders(), id='all-sliders')
+                    ], align='center'),
+                html.H4([
+                    'You can upload your own incidence data here. It will'
+                    'appear as bars, while the simulation will be a line.'
+                ]),
+                dcc.Upload(
+                    id='upload-data',
+                    children=html.Div([
+                        'Drag and Drop or ',
+                            html.A('Select Files',
+                                style={'text-decoration': 'underline'}),
+                        ' to upload your Incidence Number data.'
+                    ]),
+                    style={
+                        'width': '100%',
+                        'height': '60px',
+                        'lineHeight': '60px',
+                        'borderWidth': '1px',
+                        'borderStyle': 'dashed',
+                        'borderRadius': '5px',
+                        'textAlign': 'center',
+                        'margin': '10px'
+                    },
+                    multiple=True  # Allow multiple files to be uploaded
+                ),
+                html.Div(id='incidence-data-upload'),
+                html.Div([]), # Empty div for bottom text
+                html.Div(id='data_storage', style={'display': 'none'}),
+                html.Div(id='sim_storage', style={'display': 'none'})
+                ], fluid=True),
+            mathjax_script
+            ])
 
         # Set the app index string for mathjax
-        self.app.index_string = index_str_math
-
-        self.current_df = None
+        self.app.index_string = 'fix this'
 
     def add_text(self, text):
         """Add a block of text at the top of the app.

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -7,8 +7,6 @@
 # notice and full license details.
 #
 
-# import threading
-
 import numpy as np
 import dash
 import dash_bootstrap_components as dbc
@@ -76,8 +74,6 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
                     ),
                     html.Div(id='incidence-data-upload'),
                     html.Div([]),  # Empty div for bottom text
-                    # dcc.Store(id='data_storage'),
-                    # dcc.Store(id='sim_storage')
                     html.Div(id='data_storage', style={'display': 'none'}),
                     html.Div(id='sim_storage', style={'display': 'none'})
                     ], fluid=True),
@@ -118,7 +114,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         html.Div
             A dash html component containing the sliders
         """
-        data = self.session_data['data_storage']
+        data = self.session_data.get('data_storage')
 
         # Calculate slider values that depend on the data
         if data is not None:
@@ -130,7 +126,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         else:
             # choose values to use if there is no data
             if magnitude_init_cond is None:
-                magnitude_init_cond = 10
+                magnitude_init_cond = 1000
             bounds = (1, 30)
 
         mid_point = round(sum(bounds) / 2)
@@ -159,8 +155,11 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         plotly.Figure
             Figure with updated data and simulations
         """
-        data = self.session_data['data_storage']
-        simulations = self.session_data['sim_storage']
+        data = self.session_data.get('data_storage')
+        simulations = self.session_data.get('sim_storage')
+
+        if data is None or simulations is None:
+            raise dash.exceptions.PreventUpdate()
 
         time_label, inc_label = data.columns
         num_simulations = len(simulations.columns) - 1
@@ -187,13 +186,16 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
     def clear_simulations(self):
         """Remove all previous simulations from sim storage.
         """
-        sim = self.session_data['sim_storage']
-        data = self.session_data['data_storage']
+        simulations = self.session_data.get('sim_storage')
+        data = self.session_data.get('data_storage')
+
+        if data is None:
+            raise dash.exceptions.PreventUpdate()
 
         time_label, inc_label = data.columns
 
         # Only attempt the purge if there is data there
-        if sim is not None:
+        if simulations is not None:
             self.session_data['sim_storage'] = data[[time_label]]
 
     def add_text(self, text):
@@ -250,8 +252,11 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
         pandas.DataFrame
             Simulations storage dataframe
         """
-        data = self.session_data['data_storage']
-        simulations = self.session_data['sim_storage']
+        data = self.session_data.get('data_storage')
+        simulations = self.session_data.get('sim_storage')
+
+        if data is None:
+            raise dash.exceptions.PreventUpdate()
 
         time_label, inc_label = data.columns
         times = data[time_label]

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -230,81 +230,13 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
             self.session_data['sim_storage'] = data[['Time']]
 
     def add_text(self, text):
-        """Add a block of text at the top of the app.
-
-        This can be used to add introductory text that everyone looking at the
-        app will see right away.
-
-        Parameters
-        ----------
-        text
-            The text to add to the html div
-        """
-        self.app.layout.children[0].children[1].children.append(text)
+        self._load_text(text)
+        self.app.layout.children[0].children[1].children.append(self.text)
 
     def add_collapsed_text(self, text, title='More details...'):
-        """Add a block of collapsible text at the bottom of the app.
-
-        By default, this text will be hidden. The user can click on a button
-        with the specified title in order to view the text.
-
-        Parameters
-        ----------
-        text
-            The text to add to the html div
-        title
-            str which will be displayed on the show/hide button
-        """
-        collapse = html.Div([
-                dbc.Button(
-                    title,
-                    id='showhidebutton',
-                    color='primary',
-                ),
-                dbc.Collapse(
-                    dbc.Card(dbc.CardBody(text)),
-                    id='collapsedtext',
-                ),
-            ])
-        self.app.layout.children[0].children[-1].children.append(collapse)
-
-    def parse_contents(self, contents, filename):
-        """Load a text (csv) file into a pandas dataframe.
-
-        Parameters
-        ----------
-
-        Returns
-        -------
-        html Div
-            A div which contains a message for the user.
-        pandas.DataFrame
-            A dataframe with the loaded file. If the file load was not
-            successful, it will be None.
-        """
-        content_type, content_string = contents.split(',')
-        _, extension = os.path.splitext(filename)
-
-        decoded = base64.b64decode(content_string)
-        try:
-            if extension in ['.csv', '.txt']:
-                # Assume that the user uploaded a CSV or TXT file
-                df = pd.read_csv(
-                    io.StringIO(decoded.decode('utf-8')))
-            else:
-                return html.Div(['File type must be CSV or TXT.']), None
-        except Exception as e:
-            print(e)
-            return html.Div([
-                'There was an error processing this file.'
-            ]), None
-
-        if ('Time' not in df.columns) or (
-                'Incidence Number' not in df.columns):
-            return html.Div(['Incorrect format; file must contain a `Time` \
-                and `Incidence Number` column.']), None
-        else:
-            return html.Div(['Loaded data from: {}'.format(filename)]), df
+        self._load_collapsed_text(text, title)
+        self.app.layout.children[0].children[-3].children.append(
+            self.collapsed_text)
 
     def add_data(
             self, df=None, time_label='Time', inc_label='Incidence Number'):

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -151,6 +151,9 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
     def update_figure(self):
         """Generate a plotly figure of incidence numbers and simulated cases.
 
+        This method uses the information saved in self.session_data to populate
+        the figure.
+
         Returns
         -------
         plotly.Figure

--- a/branchpro/apps/_simulation.py
+++ b/branchpro/apps/_simulation.py
@@ -267,7 +267,7 @@ class IncidenceNumberSimulationApp(BranchProDashApp):
 
         # Generate one simulation trajectory from this model
         simulation_controller = bp.SimulationController(
-            br_pro_model, 1, len(times))
+            br_pro_model, 1, max(times))
         data = simulation_controller.run(new_init_cond)
 
         # Add data to simulations storage

--- a/branchpro/apps/inference_dash_app.py
+++ b/branchpro/apps/inference_dash_app.py
@@ -104,15 +104,15 @@ def update_data_figure(*args):
 
 @app.app.callback(
     Output('posterior-fig', 'figure'),
-    Input('data_storage', 'children'),
     Input('posterior_storage', 'children'),
+    State('data_storage', 'children'),
 )
 def update_posterior_figure(*args):
     """Handles all updates to the posterior figure.
     """
     with app.lock:
         app.refresh_user_data_json(
-            data_storage=args[0], posterior_storage=args[1])
+            data_storage=args[1], posterior_storage=args[0])
         return app.update_inference_figure()
 
 

--- a/branchpro/apps/inference_dash_app.py
+++ b/branchpro/apps/inference_dash_app.py
@@ -63,8 +63,8 @@ posterior = bp.BranchProPosterior(
 app.add_posterior(posterior)
 app.add_ground_truth_rt(r_df, time_label='Days')
 
-sliders = app.get_sliders_ids()
-
+# sliders = app.get_sliders_ids()
+sliders = ['mean', 'stdev', 'tau', 'central_prob']
 
 # Add the explanation texts
 fname = os.path.join(os.path.dirname(__file__),

--- a/branchpro/apps/inference_dash_app.py
+++ b/branchpro/apps/inference_dash_app.py
@@ -54,11 +54,6 @@ data = pd.DataFrame({
             'R_t': [np.nan] + list(model.get_r_profile())
         })
 
-r_df = pd.DataFrame({
-            'Days': times[1:],
-            'R_t': model.get_r_profile()
-        })
-
 sliders = ['mean', 'stdev', 'tau', 'central_prob']
 
 # Add the explanation texts
@@ -103,8 +98,7 @@ def update_data_figure(*args):
     """Handles all updates to the data figure.
     """
     with app.lock:
-        app.refresh_user_data_json(
-            data_storage=args[0])
+        app.refresh_user_data_json(data_storage=args[0])
         return app.update_data_figure()
 
 

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -95,6 +95,18 @@ def update_slider_ranges(*args):
 
 
 @app.app.callback(
+    Output('myfig', 'figure'),
+    Input('data_storage', 'children'),
+    Input('sim_storage', 'children'),
+)
+def update_figure(*args):
+    """Handles all updates to the incidence number figure.
+    """
+    app.refresh_user_data(data_storage=args[0], sim_storage=args[1])
+    return app.update_figure()
+
+
+@app.app.callback(
         Output('myfig', 'figure'),
         [Input(s, 'value') for s in sliders],
         Input('sim-button', 'n_clicks'),

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -41,15 +41,15 @@ french_flu_data = df
 sliders = ['init_cond', 'r0', 'r1', 't1']
 
 # Add the explanation texts
-# fname = os.path.join(os.path.dirname(__file__), 'data', 'dash_app_text.md')
-# with open(fname) as f:
-#     app.add_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
-#
-# fname = os.path.join(os.path.dirname(__file__),
-#                      'data',
-#                      'dash_app_collapsible_text.md')
-# with open(fname) as f:
-#     app.add_collapsed_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
+fname = os.path.join(os.path.dirname(__file__), 'data', 'dash_app_text.md')
+with open(fname) as f:
+    app.add_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
+
+fname = os.path.join(os.path.dirname(__file__),
+                     'data',
+                     'dash_app_collapsible_text.md')
+with open(fname) as f:
+    app.add_collapsed_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
 
 # Get server of the app; necessary for correct deployment of the app.
 server = app.app.server
@@ -127,18 +127,18 @@ def run_simulation(*args):
     return app.update_simulation(init_cond, r0, r1, t1)
 
 
-# @app.app.callback(
-#     Output('collapsedtext', 'is_open'),
-#     [Input('showhidebutton', 'n_clicks')],
-#     [State('collapsedtext', 'is_open')],
-# )
-# def toggle_hidden_text(num_clicks, is_it_open):
-#     """
-#     Switches the visibility of the hidden text.
-#     """
-#     if num_clicks:
-#         return not is_it_open
-#     return is_it_open
+@app.app.callback(
+    Output('collapsedtext', 'is_open'),
+    [Input('showhidebutton', 'n_clicks')],
+    [State('collapsedtext', 'is_open')],
+)
+def toggle_hidden_text(num_clicks, is_it_open):
+    """
+    Switches the visibility of the hidden text.
+    """
+    if num_clicks:
+        return not is_it_open
+    return is_it_open
 
 
 if __name__ == "__main__":

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -31,28 +31,25 @@ df = pd.DataFrame({
             'Incidence Number': small_ffd['inc']
         })
 
+# # TODO:  FIX this
+df = pd.DataFrame({
+            'Time': small_ffd['week'],
+            'Incidence Number': small_ffd['inc']
+        })
+
 french_flu_data = df
-
-br_pro_model = bp.BranchProModel(2, np.array([1, 2, 3, 2, 1]))
-simulationController = bp.SimulationController(
-    br_pro_model, 1, len(small_ffd['week']))
-app.add_simulator(
-    simulationController,
-    magnitude_init_cond=max(df['Incidence Number']))
-app.add_data(df, time_label='Weeks')
-
-sliders = app.get_sliders_ids()
+sliders = ['init_cond', 'r0', 'r1', 't1']
 
 # Add the explanation texts
-fname = os.path.join(os.path.dirname(__file__), 'data', 'dash_app_text.md')
-with open(fname) as f:
-    app.add_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
-
-fname = os.path.join(os.path.dirname(__file__),
-                     'data',
-                     'dash_app_collapsible_text.md')
-with open(fname) as f:
-    app.add_collapsed_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
+# fname = os.path.join(os.path.dirname(__file__), 'data', 'dash_app_text.md')
+# with open(fname) as f:
+#     app.add_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
+#
+# fname = os.path.join(os.path.dirname(__file__),
+#                      'data',
+#                      'dash_app_collapsible_text.md')
+# with open(fname) as f:
+#     app.add_collapsed_text(dcc.Markdown(f.read(), dangerously_allow_html=True))
 
 # Get server of the app; necessary for correct deployment of the app.
 server = app.app.server
@@ -125,23 +122,23 @@ def run_simulation(*args):
     ctx = dash.callback_context
     source = ctx.triggered[0]['prop_id'].split('.')[0]
     if source != 'sim-button':
-        app.purge_simulations()
+        app.clear_simulations()
 
     return app.update_simulation(init_cond, r0, r1, t1)
 
 
-@app.app.callback(
-    Output('collapsedtext', 'is_open'),
-    [Input('showhidebutton', 'n_clicks')],
-    [State('collapsedtext', 'is_open')],
-)
-def toggle_hidden_text(num_clicks, is_it_open):
-    """
-    Switches the visibility of the hidden text.
-    """
-    if num_clicks:
-        return not is_it_open
-    return is_it_open
+# @app.app.callback(
+#     Output('collapsedtext', 'is_open'),
+#     [Input('showhidebutton', 'n_clicks')],
+#     [State('collapsedtext', 'is_open')],
+# )
+# def toggle_hidden_text(num_clicks, is_it_open):
+#     """
+#     Switches the visibility of the hidden text.
+#     """
+#     if num_clicks:
+#         return not is_it_open
+#     return is_it_open
 
 
 if __name__ == "__main__":

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -79,10 +79,11 @@ def update_slider_ranges(*args):
     """Update sliders when a data file is uploaded.
     """
     data = french_flu_data if args[0] is None else args[0]
-    print('update slider is about to refresh')
-    app.refresh_user_data_json(data_storage=data)
-    print('update slider refreshed')
-    return app.update_sliders()
+    with app.lock:
+        print('update slider is about to refresh')
+        app.refresh_user_data_json(data_storage=data)
+        print('update slider refreshed')
+        return app.update_sliders()
 
 
 @app.app.callback(
@@ -94,9 +95,11 @@ def update_figure(*args):
     """Handles all updates to the incidence number figure.
     """
     print('update figure is about to refresh')
-    app.refresh_user_data_json(data_storage=args[0], sim_storage=args[1])
-    print('update figure refreshed')
-    return app.update_figure()
+
+    with app.lock:
+        app.refresh_user_data_json(data_storage=args[0], sim_storage=args[1])
+        print('update figure refreshed')
+        return app.update_figure()
 
 
 @app.app.callback(
@@ -111,17 +114,18 @@ def run_simulation(*args):
     """
     n_clicks, sim_json, data_json, init_cond, r0, r1, t1 = args
 
-    app.refresh_user_data_json(data_storage=data_json, sim_storage=sim_json)
-    print('run simulation refreshed')
-    # In all cases except the a click of the add new simulation buttom, we want
-    # to remove all previous simulation traces from the figure
-    ctx = dash.callback_context
-    source = ctx.triggered[0]['prop_id'].split('.')[0]
-    if source != 'sim-button':
-        print('run simulation is about to clear')
-        app.clear_simulations()
+    with app.lock:
+        app.refresh_user_data_json(data_storage=data_json, sim_storage=sim_json)
+        print('run simulation refreshed')
+        # In all cases except the a click of the add new simulation buttom, we want
+        # to remove all previous simulation traces from the figure
+        ctx = dash.callback_context
+        source = ctx.triggered[0]['prop_id'].split('.')[0]
+        if source != 'sim-button':
+            print('run simulation is about to clear')
+            app.clear_simulations()
 
-    return app.update_simulation(init_cond, r0, r1, t1)
+        return app.update_simulation(init_cond, r0, r1, t1).to_json()
 
 
 @app.app.callback(

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -79,7 +79,9 @@ def update_slider_ranges(*args):
     """Update sliders when a data file is uploaded.
     """
     data = french_flu_data if args[0] is None else args[0]
+    print('update slider is about to refresh')
     app.refresh_user_data_json(data_storage=data)
+    print('update slider refreshed')
     return app.update_sliders()
 
 
@@ -91,7 +93,9 @@ def update_slider_ranges(*args):
 def update_figure(*args):
     """Handles all updates to the incidence number figure.
     """
+    print('update figure is about to refresh')
     app.refresh_user_data_json(data_storage=args[0], sim_storage=args[1])
+    print('update figure refreshed')
     return app.update_figure()
 
 
@@ -108,12 +112,13 @@ def run_simulation(*args):
     n_clicks, sim_json, data_json, init_cond, r0, r1, t1 = args
 
     app.refresh_user_data_json(data_storage=data_json, sim_storage=sim_json)
-
+    print('run simulation refreshed')
     # In all cases except the a click of the add new simulation buttom, we want
     # to remove all previous simulation traces from the figure
     ctx = dash.callback_context
     source = ctx.triggered[0]['prop_id'].split('.')[0]
     if source != 'sim-button':
+        print('run simulation is about to clear')
         app.clear_simulations()
 
     return app.update_simulation(init_cond, r0, r1, t1)

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -50,14 +50,13 @@ server = app.app.server
 @app.app.callback(
     Output('incidence-data-upload', 'children'),
     Output('data_storage', 'children'),
-    Input('data_storage', 'children'),
     Input('upload-data', 'contents'),
     State('upload-data', 'filename'),
 )
 def load_data(*args):
     """Load data from a file and save it in storage.
     """
-    current_data, list_contents, list_names = args
+    list_contents, list_names = args
 
     with app.lock:
         if list_contents is not None:

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -80,9 +80,7 @@ def update_slider_ranges(*args):
     """
     data = french_flu_data if args[0] is None else args[0]
     with app.lock:
-        print('update slider is about to refresh')
         app.refresh_user_data_json(data_storage=data)
-        print('update slider refreshed')
         return app.update_sliders()
 
 
@@ -94,11 +92,8 @@ def update_slider_ranges(*args):
 def update_figure(*args):
     """Handles all updates to the incidence number figure.
     """
-    print('update figure is about to refresh')
-
     with app.lock:
         app.refresh_user_data_json(data_storage=args[0], sim_storage=args[1])
-        print('update figure refreshed')
         return app.update_figure()
 
 
@@ -115,14 +110,14 @@ def run_simulation(*args):
     n_clicks, sim_json, data_json, init_cond, r0, r1, t1 = args
 
     with app.lock:
-        app.refresh_user_data_json(data_storage=data_json, sim_storage=sim_json)
-        print('run simulation refreshed')
-        # In all cases except the a click of the add new simulation buttom, we want
-        # to remove all previous simulation traces from the figure
+        app.refresh_user_data_json(
+            data_storage=data_json, sim_storage=sim_json)
+
+        # In all cases except a click of the add new simulation buttom, we
+        # want to remove all previous simulation traces from the figure
         ctx = dash.callback_context
         source = ctx.triggered[0]['prop_id'].split('.')[0]
         if source != 'sim-button':
-            print('run simulation is about to clear')
             app.clear_simulations()
 
         return app.update_simulation(init_cond, r0, r1, t1).to_json()

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -84,19 +84,14 @@ def load_data(*args):
 
 @app.app.callback(
     Output('all-sliders', 'children'),
-    Input('incidence-data-upload', 'children')
+    Input('data_storage', 'children'),
 )
-def update_sliders(*args):
+def update_slider_ranges(*args):
+    """Update sliders when a data file is uploaded.
     """
-    Update sliders when a data file is uploaded.
-    """
-    data = app.current_df
-    if data is not None:
-        # Send the new sliders div to the callback output
-        return app.sliders.get_sliders_div()
-    else:
-        # There is no loaded data, so make no change to the output
-        raise dash.exceptions.PreventUpdate()
+    data = french_flu_data if args[0] is None else args[0]
+    app.refresh_user_data_json(data_storage=data)
+    return app.update_sliders()
 
 
 @app.app.callback(

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -12,7 +12,6 @@ with fixed example data. To run the app, use ``python dash_app.py``.
 
 import os
 
-import numpy as np
 import pandas as pd
 import dash
 import dash_core_components as dcc
@@ -31,11 +30,6 @@ df = pd.DataFrame({
             'Incidence Number': small_ffd['inc']
         })
 
-# # TODO:  FIX this
-df = pd.DataFrame({
-            'Time': small_ffd['week'],
-            'Incidence Number': small_ffd['inc']
-        })
 
 french_flu_data = df
 sliders = ['init_cond', 'r0', 'r1', 't1']

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -155,4 +155,4 @@ def toggle_hidden_text(num_clicks, is_it_open):
 
 
 if __name__ == "__main__":
-    app.app.run_server(debug=True, threaded=False, processes=1)
+    app.app.run_server(debug=True)

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -10,7 +10,6 @@
 with fixed example data. To run the app, use ``python dash_app.py``.
 """
 
-import copy
 import os
 
 import pandas as pd
@@ -63,7 +62,8 @@ def load_data(*args):
         if list_contents is not None:
             # Run content parser for each file and get message
             # Only use latest file
-            message, data = app.parse_contents(list_contents[-1], list_names[-1])
+            message, data = app.parse_contents(list_contents[-1],
+                                               list_names[-1])
 
             if data is None:
                 # The file could not be loaded, so keep the current data and
@@ -111,38 +111,7 @@ def update_figure(*args):
     with app.lock:
         app.refresh_user_data_json(data_storage=data_json)
         new_sim = app.update_simulation(init_cond, r0, r1, t1)
-
-        if len(fig['data']) == 0 or source == 'all-sliders':
-            # Either this figure is empty or the sliders are new. Both cases
-            # demand a new incidence number plot be generated.
-            return app.update_figure(simulations=new_sim)
-
-        elif source in sliders:
-            # Clear all data except one simulation trace
-            fig['data'] = [fig['data'][0], fig['data'][-1]]
-
-            # Set the y data of that trace equal to an updated simulation
-            fig['data'][-1]['y'] = new_sim.iloc[:, -1]
-
-            return fig
-
-        elif source == 'sim-button':
-            # Add one extra simulation, and set its y data
-            fig['data'].append(copy.deepcopy(fig['data'][-1]))
-            fig['data'][-1]['y'] = new_sim.iloc[:, -1]
-
-            for i in range(len(fig['data'])-2):
-                # Change opacity of all traces in the figure but for the
-                # first - the barplot of incidences
-                # last - the latest simulation
-                fig['data'][i+1]['line']['color'] = 'rgba(255,0,0,0.25)'
-                fig['data'][i+1]['showlegend'] = False
-
-            return fig
-
-        else:
-            # Input not recognized
-            raise dash.exceptions.PreventUpdate()
+        return app.update_figure(fig=fig, simulations=new_sim, source=source)
 
 
 @app.app.callback(

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -25,13 +25,11 @@ from branchpro.apps import IncidenceNumberSimulationApp
 app = IncidenceNumberSimulationApp()
 full_ffd = bp.DatasetLibrary().french_flu()
 small_ffd = full_ffd.query('year == 2020')
-df = pd.DataFrame({
+french_flu_data = pd.DataFrame({
             'Weeks': small_ffd['week'],
             'Incidence Number': small_ffd['inc']
         })
 
-
-french_flu_data = df
 sliders = ['init_cond', 'r0', 'r1', 't1']
 
 # Add the explanation texts

--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -44,10 +44,10 @@ Simulation Apps
 ***************
 
 .. autoclass:: IncidenceNumberSimulationApp
-  :members: add_data, add_simulator, get_sliders_ids, update_simulation
+  :members: update_sliders, update_figure, update_simulation, clear_simulations, add_text, add_collapsed_text,
 
 Inference Apps
 ***************
 
 .. autoclass:: BranchProInferenceApp
-  :members: add_ground_truth_rt, add_posterior, get_sliders_ids, update_inference
+  :members: add_ground_truth_rt, add_posterior, update_inference

--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -1,5 +1,5 @@
 ******************
-Visualisation Apps 
+Visualisation Apps
 ******************
 
 .. currentmodule:: branchpro
@@ -9,6 +9,7 @@ Overview:
 - :class:`IncidenceNumberPlot`
 - :class:`ReproductionNumberPlot`
 - :class:`_SliderComponent`
+- :class:`BranchProDashApp`
 - :class:`IncidenceNumberSimulationApp`
 - :class:`BranchProInferenceApp`
 
@@ -30,6 +31,14 @@ Sliders
 
 .. autoclass:: _SliderComponent
   :members: add_slider, get_sliders_div, slider_ids
+
+
+Apps
+****
+
+.. autoclass:: BranchProDashApp
+  :members: refresh_user_data_json, parse_contents
+
 
 Simulation Apps
 ***************

--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -37,17 +37,17 @@ Apps
 ****
 
 .. autoclass:: BranchProDashApp
-  :members: refresh_user_data_json, parse_contents
+  :members: refresh_user_data_json, parse_contents, add_text, add_collapsed_text
 
 
 Simulation Apps
 ***************
 
 .. autoclass:: IncidenceNumberSimulationApp
-  :members: update_sliders, update_figure, update_simulation, clear_simulations, add_text, add_collapsed_text
+  :members: update_sliders, update_figure, update_simulation
 
 Inference Apps
 ***************
 
 .. autoclass:: BranchProInferenceApp
-  :members: update_sliders, update_posterior, update_inference_figure, update_data_figure, add_text, add_collapsed_text
+  :members: update_sliders, update_posterior, update_inference_figure, update_data_figure

--- a/docs/source/apps.rst
+++ b/docs/source/apps.rst
@@ -44,10 +44,10 @@ Simulation Apps
 ***************
 
 .. autoclass:: IncidenceNumberSimulationApp
-  :members: update_sliders, update_figure, update_simulation, clear_simulations, add_text, add_collapsed_text,
+  :members: update_sliders, update_figure, update_simulation, clear_simulations, add_text, add_collapsed_text
 
 Inference Apps
 ***************
 
 .. autoclass:: BranchProInferenceApp
-  :members: add_ground_truth_rt, add_posterior, update_inference
+  :members: update_sliders, update_posterior, update_inference_figure, update_data_figure, add_text, add_collapsed_text


### PR DESCRIPTION
Closes #99
Closes #100
Closes #102

The purpose of this PR is to eliminate the erroneous usage of instance variables on IncidenceNumberSimulationApp and BranchProInferenceApp for the storage of user data and other user-specific objects between callbacks. All faulty callbacks have been rewritten, and the app methods have been rewritten to work correctly with the new callbacks.

As it is not always convenient to access user data from the plotly figures, support has been added for storage HTML divs, hidden via CSS, intended for the holding of pandas dataframes in JSON format. This method is lightweight, straightforward, and attested in the [dash documentation](https://dash.plotly.com/sharing-data-between-callbacks) among other places. A very similar alternative would be the dcc.Store objects. I tested both and found the HTML divs slightly faster; they also have the advantage of being far more robust to unusual browser settings.

In order to avoid duplication of the storage code, a base class was made for both apps. 

The code has been manually tested on heroku (though not on the correct account).