### PR TITLE
teach users to run inference app locally

### DIFF
--- a/.github/workflows/os-unittests.yml
+++ b/.github/workflows/os-unittests.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/os-unittests.yml
+++ b/.github/workflows/os-unittests.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ In this package, we use branching processes to model the time-dependent reproduc
 All features of our software are described in detail in our
 [full API documentation](https://branchpro.readthedocs.io/en/latest/).
 
-<!---
-A web app for performing inference for branching process models can be found [here](https://sabs-r3-epidemiology.github.io/branchpro/).
--->
+
+A web app for performing inference for branching process models is included in this package. Instructions for accessing the app are available [here](https://sabs-r3-epidemiology.github.io/branchpro/).
+
 
 More details on branching process models and inference can be found in these
 papers:

--- a/branchpro/apps/inference_dash_app.py
+++ b/branchpro/apps/inference_dash_app.py
@@ -300,4 +300,4 @@ def toggle_modal_si(n1, n2, is_open):
 
 
 if __name__ == "__main__":
-    app.app.run_server(debug=True)
+    app.app.run_server(debug=True, host='127.0.0.1', port=8050)

--- a/branchpro/apps/simulation_dash_app.py
+++ b/branchpro/apps/simulation_dash_app.py
@@ -7,7 +7,7 @@
 # notice and full license details.
 #
 """This is an app which shows forward simulation of the branching process model
-with fixed example data. To run the app, use ``python dash_app.py``.
+with fixed example data. To run the app, use ``python simulation_dash_app.py``.
 """
 
 import os
@@ -199,4 +199,4 @@ def toggle_modal_si(n1, n2, is_open):
 
 
 if __name__ == "__main__":
-    app.app.run_server(debug=True)
+    app.app.run_server(debug=True, host='127.0.0.1', port=8050)

--- a/index.html
+++ b/index.html
@@ -39,7 +39,14 @@
       <h2 class="title">Inference Web App for Branching Processes</h2>
       <hr>
       <p>
-        To access our online software application, please click <a href="https://branchproinf.herokuapp.com">here.</a>
+        <span style="color:red;">The online web server for the branchpro inference app is currently down.</span> To access the app in your browser, please install the branchpro software (see Github link below) and then execute the following command:
+      </p>
+      <pre style="margin-left: 30px;"><code>python branchpro/apps/inference_dash_app.py</code></pre>
+      <p>
+        Subsequently, navigate to the address <code>http://127.0.0.1:8050/</code> on your preferred web browser to access the app.
+      </p>
+      <p>
+        Alternatively, all the functionality of the app can be accessed in Python code using the branchpro package; please refer to the <a href="https://branchpro.readthedocs.io/en/latest/" target=”_blank”>API documentation.</a>
       </p>
       <p>
         To access the software repository for the branchpro Python package, please click <a href="https://github.com/SABS-R3-Epidemiology/branchpro">here.</a>

--- a/index.html
+++ b/index.html
@@ -39,7 +39,10 @@
       <h2 class="title">Inference Web App for Branching Processes</h2>
       <hr>
       <p>
-        <span style="color:red;">The online web server for the branchpro inference app is currently down.</span> To access the app in your browser, please install the branchpro software (see Github link below) and then execute the following command:
+        To access the software repository for the branchpro Python package, please visit the Github <a href="https://github.com/SABS-R3-Epidemiology/branchpro">here.</a>
+      </p>
+      <p>
+        <span style="color:red;">The online web server for the branchpro inference app is currently down.</span> To access the app locally in your browser, please install the branchpro software (see Github link above) and then execute the following command:
       </p>
       <pre style="margin-left: 30px;"><code>python branchpro/apps/inference_dash_app.py</code></pre>
       <p>
@@ -47,9 +50,6 @@
       </p>
       <p>
         Alternatively, all the functionality of the app can be accessed in Python code using the branchpro package; please refer to the <a href="https://branchpro.readthedocs.io/en/latest/" target=”_blank”>API documentation.</a>
-      </p>
-      <p>
-        To access the software repository for the branchpro Python package, please click <a href="https://github.com/SABS-R3-Epidemiology/branchpro">here.</a>
       </p>
       <p>
         The authors request users to cite the original publication when referring to the software application, any results generated from it, or any of the code on which this tool is based:


### PR DESCRIPTION
We link to the app landing page in the first section of the 2022 paper (and some other places I have recently mentioned this...) so I think we should try and avoid having a flagrant broken link from the heroku.

Obviously it would be ideal to do another deployment, but as a makeshift solution I would suggest just instructing them how to run the app locally using the package, which is what this PR implements, but happy to hear any other suggestions.